### PR TITLE
Add RequestAuth type to replace `Map.Entry` usage.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 
 // Project settings
 group   = "org.veupathdb.lib"
-version = "6.6.0"
+version = "7.0.0"
 
 plugins {
   `java-library`
@@ -93,7 +93,7 @@ dependencies {
 
   // Unit Testing
   testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
-  testImplementation("org.mockito:mockito-core:4.3.1")
+  testImplementation("org.mockito:mockito-core:4.6.1")
 }
 
 tasks.jar {

--- a/src/main/java/org/veupathdb/lib/container/jaxrs/model/RequestAuth.java
+++ b/src/main/java/org/veupathdb/lib/container/jaxrs/model/RequestAuth.java
@@ -4,6 +4,17 @@ import java.util.Map;
 
 /**
  * Request Auth Token/Header
+ *
+ * Wraps the authentication information for a request.
+ *
+ * @apiNote This type presently implements the interface {@link Map.Entry}.
+ * This is temporary and was done to ease the transition of consumers of this
+ * library from older versions.  When all known consumers of this library have
+ * been updated to declare their types as {@link RequestAuth} instead of
+ * {@code Map.Entry}, the implements should be dropped.
+ *
+ * @author Elizabeth Paige Harper (https://github.com/foxcapades)
+ * @since v7.0.0
  */
 public class RequestAuth implements Map.Entry<String, String> {
   private final String header;

--- a/src/main/java/org/veupathdb/lib/container/jaxrs/model/RequestAuth.java
+++ b/src/main/java/org/veupathdb/lib/container/jaxrs/model/RequestAuth.java
@@ -1,0 +1,48 @@
+package org.veupathdb.lib.container.jaxrs.model;
+
+import java.util.Map;
+
+/**
+ * Request Auth Token/Header
+ */
+public class RequestAuth implements Map.Entry<String, String> {
+  private final String header;
+
+  private final String token;
+
+  public RequestAuth(String header, String token) {
+    this.header = header;
+    this.token  = token;
+  }
+
+  public String getHeader() {
+    return header;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  @Override
+  public String toString() {
+    return "AuthHeader(header="+header+", secret=***)";
+  }
+
+  @Override
+  @Deprecated
+  public String getKey() {
+    return header;
+  }
+
+  @Override
+  @Deprecated
+  public String getValue() {
+    return token;
+  }
+
+  @Override
+  @Deprecated
+  public String setValue(String value) {
+    throw new UnsupportedOperationException("RequestAuth instance values cannot be changed.");
+  }
+}

--- a/src/main/java/org/veupathdb/lib/container/jaxrs/providers/UserProvider.java
+++ b/src/main/java/org/veupathdb/lib/container/jaxrs/providers/UserProvider.java
@@ -1,11 +1,10 @@
 package org.veupathdb.lib.container.jaxrs.providers;
 
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import org.glassfish.jersey.server.ContainerRequest;
-import org.gusdb.fgputil.Tuples.TwoTuple;
 import org.veupathdb.lib.container.jaxrs.Globals;
+import org.veupathdb.lib.container.jaxrs.model.RequestAuth;
 import org.veupathdb.lib.container.jaxrs.model.User;
 import org.veupathdb.lib.container.jaxrs.server.middleware.AuthFilter;
 import org.veupathdb.lib.container.jaxrs.utils.RequestKeys;
@@ -18,7 +17,7 @@ public class UserProvider {
       .map(User.class::cast);
   }
 
-  public static Optional<Entry<String,String>> getSubmittedAuth(ContainerRequest req) {
+  public static Optional<RequestAuth> getSubmittedAuth(ContainerRequest req) {
     String auth = Optional.ofNullable(Objects
       // caller must pass a non-null request
       .requireNonNull(req)
@@ -32,6 +31,6 @@ public class UserProvider {
 
     // convert value to Entry if present
     return Optional.ofNullable(auth)
-      .map(s -> new TwoTuple<>(RequestKeys.AUTH_HEADER, s));
+      .map(s -> new RequestAuth(RequestKeys.AUTH_HEADER, s));
   }
 }


### PR DESCRIPTION
### Change

Added the concrete type `RequestAuth` to represent the request authentication header/info as an alternative to passing around a raw `Map.Entry` instance.

The new type presently implements `Map.Entry` itself to ease the change over from using that type.  This is temporary and should be removed by `v8` (or a later major release).

### Reasoning

The usage of `Map.Entry` instead of a new or alternative type for this is abusing a type internal to `Map` for reasons that are unrelated to the defined purpose of the type. 

Additionally, there are few to no available standard library implementations of the `Map.Entry` interface that are not part of or included within a `Map` implementation (most of which are private or package-private), meaning consumers of this library will also need to rely on code from an additional library (FgpUtil) or implement `Map.Entry` themselves.

### Impact on Library Consumers

While this is technically a "breaking change" the new type implements `Map.Entry` so most if not all consumers of this library will be unaffected by the update.   Consumers of this library should update their calls to `UserProvider.getSubmittedAuth` to declare the type `RequestAuth` instead of `Map.Entry` type as the new type `RequestAuth` will be updated in the future to no longer implement `Map.Entry`.