### PR TITLE
Added validation to authorization filter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,7 @@ dependencies {
   // Unit Testing
   testImplementation("org.junit.jupiter:junit-jupiter:5.9.0")
   testImplementation("org.mockito:mockito-core:4.8.0")
+  testImplementation("org.mockito:mockito-junit-jupiter:4.8.0")
 }
 
 tasks.jar {

--- a/src/main/java/org/veupathdb/lib/container/jaxrs/server/middleware/AuthFilter.java
+++ b/src/main/java/org/veupathdb/lib/container/jaxrs/server/middleware/AuthFilter.java
@@ -64,7 +64,9 @@ public class AuthFilter implements ContainerRequestFilter
     this.opts = opts;
 
     // Only validate that the secret key is present if we actually need it.
-    if (opts.getAuthSecretKey().isEmpty())
+    if (opts.getAuthSecretKey()
+        .filter(secretKey -> !secretKey.isBlank())
+        .isEmpty())
       throw new InvalidConfigException("Auth secret key is required for this "
         + "service");
   }

--- a/src/test/java/org/veupathdb/lib/container/jaxrs/server/middleware/AuthFilterTest.java
+++ b/src/test/java/org/veupathdb/lib/container/jaxrs/server/middleware/AuthFilterTest.java
@@ -1,0 +1,58 @@
+package org.veupathdb.lib.container.jaxrs.server.middleware;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.veupathdb.lib.container.jaxrs.config.InvalidConfigException;
+import org.veupathdb.lib.container.jaxrs.config.Options;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthFilterTest {
+
+  @Mock private Options options;
+  @Mock private ContainerRequestContext requestContext;
+  @Mock private UriInfo uriInfo;
+
+  @Test
+  public void testConstructMissingAuthKey() {
+    when(options.getAuthSecretKey()).thenReturn(Optional.empty());
+    Assertions.assertThrows(InvalidConfigException.class, () -> new AuthFilter(options));
+  }
+
+  @Test
+  public void testConstructBlankAuthKey() {
+    when(options.getAuthSecretKey()).thenReturn(Optional.of(""));
+    Assertions.assertThrows(InvalidConfigException.class, () -> new AuthFilter(options));
+  }
+
+  @Test
+  public void testMissingAuthInRequest() {
+    final MultivaluedHashMap<String, String> empty = new MultivaluedHashMap<>();
+    when(options.getAuthSecretKey()).thenReturn(Optional.of("auth-key"));
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+
+    // Return empty headers and empty query params. No auth information is provided.
+    when(requestContext.getHeaders()).thenReturn(empty);
+    when(uriInfo.getQueryParameters()).thenReturn(empty);
+
+    // Mock authRequirement method, since it resourceInfo cannot be injected in test context.
+    AuthFilter authFilter = Mockito.spy(new AuthFilter(options));
+    doReturn(AuthFilter.AuthRequirement.RequiredDisallowGuests).when(authFilter).authRequirement(Mockito.any());
+
+    authFilter.filter(requestContext);
+
+    // Verify request is aborted due to missing auth key.
+    Mockito.verify(requestContext).abortWith(Mockito.any());
+  }
+}


### PR DESCRIPTION
Resolves #25 

Simple fix just to verify auth secret key is not blank. This is important because docker compose passes an empty value and emits a warning if a variable is missing from `.env`

Added a few unit tests as well.