### PR TITLE
Ensure request ID is maintained throughout entire request

### DIFF
--- a/src/main/java/org/veupathdb/lib/container/jaxrs/server/middleware/PrometheusFilter.java
+++ b/src/main/java/org/veupathdb/lib/container/jaxrs/server/middleware/PrometheusFilter.java
@@ -71,7 +71,6 @@ implements ContainerRequestFilter, ContainerResponseFilter, WriterInterceptor {
     fn.accept(() -> format(START_FORMAT, req.getMethod(), "/" + path));
     String pathTemplate = getPathTemplate(req);
     req.setProperty(MATCHED_URL_KEY, pathTemplate);
-    LOG.info("Matched template: " + getPathTemplate(req) + ". Starting timer with path a label.");
     req.setProperty(
       TIME_KEY,
       reqTime.labels(
@@ -122,7 +121,6 @@ implements ContainerRequestFilter, ContainerResponseFilter, WriterInterceptor {
       context.removeProperty(METHOD_KEY);
       context.removeProperty(IS_ERROR_KEY);
 
-      LOG.info("Observing duration with request body.");
       ((Timer) context.getProperty(TIME_KEY))
           .observeDuration();
       context.removeProperty(TIME_KEY);

--- a/src/main/java/org/veupathdb/lib/container/jaxrs/server/middleware/RequestIdFilter.java
+++ b/src/main/java/org/veupathdb/lib/container/jaxrs/server/middleware/RequestIdFilter.java
@@ -1,7 +1,6 @@
 package org.veupathdb.lib.container.jaxrs.server.middleware;
 
 import com.devskiller.friendly_id.FriendlyId;
-import io.prometheus.client.Histogram;
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;

--- a/src/main/java/org/veupathdb/lib/container/jaxrs/server/middleware/RequestIdFilter.java
+++ b/src/main/java/org/veupathdb/lib/container/jaxrs/server/middleware/RequestIdFilter.java
@@ -1,14 +1,18 @@
 package org.veupathdb.lib.container.jaxrs.server.middleware;
 
 import com.devskiller.friendly_id.FriendlyId;
+import io.prometheus.client.Histogram;
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.container.PreMatching;
 import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.WriterInterceptor;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
@@ -17,6 +21,8 @@ import org.veupathdb.lib.container.jaxrs.Globals;
 import org.veupathdb.lib.container.jaxrs.utils.RequestKeys;
 import org.veupathdb.lib.container.jaxrs.utils.logging.LoggingVars;
 
+import java.io.IOException;
+
 /**
  * Assigns a unique ID to each request for logging, error tracing purposes.
  */
@@ -24,7 +30,7 @@ import org.veupathdb.lib.container.jaxrs.utils.logging.LoggingVars;
 @Priority(0)
 @PreMatching
 public class RequestIdFilter
-implements ContainerRequestFilter, ContainerResponseFilter {
+implements ContainerRequestFilter, ContainerResponseFilter, WriterInterceptor {
 
   private static final Logger LOG = LogManager.getLogger(RequestIdFilter.class);
 
@@ -52,8 +58,28 @@ implements ContainerRequestFilter, ContainerResponseFilter {
   }
 
   @Override
+  public void aroundWriteTo(WriterInterceptorContext context) throws IOException, WebApplicationException {
+    LOG.trace("RequestIdFilter#aroundWriteTo(context)");
+    try {
+      // write the response
+      context.proceed();
+    }
+    finally {
+      removeContext();
+    }
+  }
+
+  @Override
   public void filter(ContainerRequestContext req, ContainerResponseContext res) {
     LOG.trace("RequestIdFilter#filter(req, res)");
+    // Remove request ID from thread context only if we have no response body.
+    // If we have a response body rely on aroundWriteTo to remove from thread context.
+    if (!res.hasEntity()) {
+      removeContext();
+    }
+  }
+
+  private void removeContext() {
     ThreadContext.remove(Globals.CONTEXT_ID);
     LoggingVars.clear();
   }


### PR DESCRIPTION
## Overview
* Removed some verbose log lines I had added previously in PrometheusFilter
* Ensure RequestId is maintained throughout streaming of response.

## Testing
Ran subsetting service and hit tabular endpoint. Verified log lines were there (and that they were removed before next request).