### PR TITLE
Add trace id to thread context

### DIFF
--- a/src/main/java/org/veupathdb/lib/container/jaxrs/Globals.java
+++ b/src/main/java/org/veupathdb/lib/container/jaxrs/Globals.java
@@ -9,5 +9,6 @@ public final class Globals {
   public static final String
     CONTEXT_ID = "context-id",
     REQUEST_USER = "user-profile",
+    TRACE_ID_HEADER = "traceparent",
     X_CONTEXT_ID = "X-Context-Id";
 }

--- a/src/main/java/org/veupathdb/lib/container/jaxrs/server/middleware/PrometheusFilter.java
+++ b/src/main/java/org/veupathdb/lib/container/jaxrs/server/middleware/PrometheusFilter.java
@@ -121,9 +121,12 @@ implements ContainerRequestFilter, ContainerResponseFilter, WriterInterceptor {
       context.removeProperty(METHOD_KEY);
       context.removeProperty(IS_ERROR_KEY);
 
-      ((Timer) context.getProperty(TIME_KEY))
-          .observeDuration();
-      context.removeProperty(TIME_KEY);
+      final String matchedUrlKey = (String) context.getProperty(MATCHED_URL_KEY);
+      if (matchedUrlKey != null) {
+        ((Timer) context.getProperty(TIME_KEY))
+            .observeDuration();
+        context.removeProperty(TIME_KEY);
+      }
     }
   }
 

--- a/src/main/java/org/veupathdb/lib/container/jaxrs/server/middleware/RequestIdFilter.java
+++ b/src/main/java/org/veupathdb/lib/container/jaxrs/server/middleware/RequestIdFilter.java
@@ -21,6 +21,7 @@ import org.veupathdb.lib.container.jaxrs.utils.RequestKeys;
 import org.veupathdb.lib.container.jaxrs.utils.logging.LoggingVars;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Assigns a unique ID to each request for logging, error tracing purposes.
@@ -46,11 +47,16 @@ implements ContainerRequestFilter, ContainerResponseFilter, WriterInterceptor {
     var requestId = FriendlyId.createFriendlyId();
     requestCxt.setProperty(RequestKeys.REQUEST_ID, requestId);
     request.setAttribute(RequestKeys.REQUEST_ID, requestId);
+
     ThreadContext.put(Globals.CONTEXT_ID, requestId);
 
+    final String traceId = Optional.ofNullable(request.getHeader(Globals.TRACE_ID_HEADER))
+        .orElse(FriendlyId.createFriendlyId());
+
     LoggingVars.setRequestThreadVars(requestId,
-      request.getSession().getIdInternal(),
-      request.getRemoteAddr());
+        request.getSession().getIdInternal(),
+        request.getRemoteAddr(),
+        traceId);
 
     // At the end so it has the context id
     LOG.trace("RequestIdFilter#filter(requestCxt)");

--- a/src/main/java/org/veupathdb/lib/container/jaxrs/utils/logging/LoggingVars.java
+++ b/src/main/java/org/veupathdb/lib/container/jaxrs/utils/logging/LoggingVars.java
@@ -13,16 +13,21 @@ public class LoggingVars {
     SHORT_SESSION_ID = "sessionId",
     SHORT_REQUEST_ID = "requestId",
     REQUEST_START = "requestTimer",
+    TRACE_ID = "traceId",
     IP_ADDRESS = "ipAddress";
 
   public static void setNonRequestThreadVars(String threadId) {
-    setRequestThreadVars(threadId, threadId, "<no_ip_address>");
+    setRequestThreadVars(threadId, threadId, "<no_ip_address>", threadId);
   }
 
-  public static void setRequestThreadVars(String requestId, String sessionId, String ipAddress) {
+  public static void setRequestThreadVars(String requestId,
+                                          String sessionId,
+                                          String ipAddress,
+                                          String traceId) {
     ThreadContext.put(SHORT_REQUEST_ID, shorten(requestId));
     ThreadContext.put(SHORT_SESSION_ID, shorten(sessionId));
     ThreadContext.put(IP_ADDRESS, ipAddress);
+    ThreadContext.put(TRACE_ID, traceId);
     ThreadContext.put(REQUEST_START, String.valueOf(System.currentTimeMillis()));
   }
 
@@ -34,6 +39,7 @@ public class LoggingVars {
     ThreadContext.remove(SHORT_REQUEST_ID);
     ThreadContext.remove(SHORT_SESSION_ID);
     ThreadContext.remove(IP_ADDRESS);
+    ThreadContext.remove(TRACE_ID);
     ThreadContext.remove(REQUEST_START);
   }
 }

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -9,8 +9,8 @@ Configuration:
         # TODO: determine if the following should be added:
         #   1. request timer (e.g. %9cmdc{requestTimer}); should reference RequestDurationPatternConverter but not working
         #   2. IP address (e.g. %15X{ipAddress}); will this show us real remote IP in docker containers?
-        #   3. session ID (e.g. sid:%-5X{sessionId}); is this useful since many containerized services will be stateless?
-        pattern: "%highlight{%d{yyyy-MM-dd HH:mm:ss.SSS} [rid:%5X{requestId}] %-5level %c{1}:%L - %m%n}"
+        #   3. Trace ID (e.g. traceId:%-5X{sessionId}); A distributed trace identifier that tracks a request throughout services
+        pattern: "%highlight{%d{yyyy-MM-dd HH:mm:ss.SSS} [rid:%5X{traceId}] %-5level %c{1}:%L - %m%n}"
   Loggers:
     Root:
       level: debug

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -9,7 +9,6 @@ Configuration:
         # TODO: determine if the following should be added:
         #   1. request timer (e.g. %9cmdc{requestTimer}); should reference RequestDurationPatternConverter but not working
         #   2. IP address (e.g. %15X{ipAddress}); will this show us real remote IP in docker containers?
-        #   3. Trace ID (e.g. traceId:%-5X{sessionId}); A distributed trace identifier that tracks a request throughout services
         pattern: "%highlight{%d{yyyy-MM-dd HH:mm:ss.SSS} [rid:%5X{traceId}] %-5level %c{1}:%L - %m%n}"
   Loggers:
     Root:


### PR DESCRIPTION
Adding thread context to Log4j in container core.

If no thread context is provided, generate one.