### PR TITLE
Fix the duration metrics and upgrade jvm stats

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
   // Metrics
   implementation("io.prometheus:simpleclient:0.16.0")
   implementation("io.prometheus:simpleclient_common:0.16.0")
-  api("org.veupathdb.lib:lib-prometheus-stats:1.1.0")
+  api("org.veupathdb.lib:lib-prometheus-stats:1.2.3")
 
   // Unique, human readable id generation
   implementation("com.devskiller.friendly-id:friendly-id:1.1.0")

--- a/src/test/java/org/veupathdb/lib/container/jaxrs/server/middleware/PrometheusFilterTest.java
+++ b/src/test/java/org/veupathdb/lib/container/jaxrs/server/middleware/PrometheusFilterTest.java
@@ -69,6 +69,7 @@ class PrometheusFilterTest {
     when(res.getStatus()).thenReturn(0);
     when(req.getProperty(TIME_KEY)).thenReturn(timer);
     when(req.getProperty(MATCHED_URL_KEY)).thenReturn("url");
+    when(timer.observeDuration()).thenReturn(100.0);
 
     var i = LogProvider.class.getDeclaredField("instance");
     i.setAccessible(true);
@@ -76,6 +77,7 @@ class PrometheusFilterTest {
 
     new PrometheusFilter().filter(req, res);
 
+    verify(timer, times(1)).observeDuration();
     verify(stat, times(1)).getLogger(PrometheusFilter.class);
     verify(log, times(1)).debug((Supplier<?>) any());
   }


### PR DESCRIPTION
## Overview
* Ensure duration metrics get emitted with or without response body.
* Add a response duration summary metrics to capture 95th percentile, 90th percentile and median durations
* Update the jvm metrics lib