### PR TITLE
Use absence from acctdb to check guests vs presence in userdb

### DIFF
--- a/src/main/java/org/veupathdb/lib/container/jaxrs/repo/SQL.java
+++ b/src/main/java/org/veupathdb/lib/container/jaxrs/repo/SQL.java
@@ -26,6 +26,8 @@ final class SQL
           private static final String table = Tables.AccountDB.UserAccounts.Accounts;
 
           static final String ByEmail = select(db, schema, table, "by-email");
+
+          static final String ById = select(db, schema, table, "by-id");
         }
       }
     }

--- a/src/main/java/org/veupathdb/lib/container/jaxrs/repo/UserRepo.java
+++ b/src/main/java/org/veupathdb/lib/container/jaxrs/repo/UserRepo.java
@@ -23,6 +23,15 @@ public class UserRepo
       ).execute().getValue();
     }
 
+    public static Optional<User> registeredUserById(long id) throws Exception {
+      return new BasicPreparedReadQuery<>(
+          SQL.Select.AccountDB.UserAccounts.Accounts.ById,
+          DbManager.accountDatabase().getDataSource()::getConnection,
+          Select::acctDB2User,
+          StatementPreparer.singleLong(id)
+      ).execute().getValue();
+    }
+
     public static Optional<User> registeredUserByEmail(String email) throws Exception {
       return new BasicPreparedReadQuery<>(
         SQL.Select.AccountDB.UserAccounts.Accounts.ByEmail,

--- a/src/main/resources/sql/select/account-db/useraccounts/accounts/by-id.sql
+++ b/src/main/resources/sql/select/account-db/useraccounts/accounts/by-id.sql
@@ -1,0 +1,31 @@
+WITH
+  id AS (
+    SELECT
+      user_id
+    FROM
+      useraccounts.accounts
+    WHERE
+      user_id = ?
+  )
+, props AS (
+  SELECT
+    key
+  , value
+  FROM
+    useraccounts.account_properties
+  WHERE
+    user_id = (SELECT user_id FROM id)
+)
+SELECT
+  u.user_id
+, u.email
+, u.signature
+, u.stable_id
+, (SELECT value FROM props WHERE key = 'first_name')   AS first_name
+, (SELECT value FROM props WHERE key = 'middle_name')  AS middle_name
+, (SELECT value FROM props WHERE key = 'last_name')    AS last_name
+, (SELECT value FROM props WHERE key = 'organization') AS organization
+FROM
+  useraccounts.accounts u
+WHERE
+  user_id = (SELECT user_id FROM id)


### PR DESCRIPTION
Rather than check userdb for presence of the guest user ID to validate guest Auth-Key values, we will check for the ID in acctdb.  If present, we know it cannot be a guest because it is a registered user.  This is to remove a specific userdb as a dependency on services that serve sites using different userdbs.  The biggest hole here is that someone could send an ID that is higher than the current ID sequence; then later that ID could be assigned to a new registered user.  If that happens, the new registered user will "inherit" (and steal) the spoof-guest's data.  Serves them right for not using a legit guest ID.